### PR TITLE
Querybuilder for communibase?

### DIFF
--- a/src/Communibase/Query/ExpressionBuilder.php
+++ b/src/Communibase/Query/ExpressionBuilder.php
@@ -1,0 +1,173 @@
+<?php
+namespace Communibase\Query;
+
+/**
+ * @package Communibase
+ * @author Kingsquare (source@kingsquare.nl)
+ * @copyright Copyright (c) Kingsquare BV (http://www.kingsquare.nl)
+ */
+class ExpressionBuilder {
+
+	/**
+	 * @param $values
+	 *
+	 * @return array
+	 */
+	public function orX($values) {
+		return [
+				'$or' => $values
+		];
+	}
+
+	/**
+	 * @param $values
+	 *
+	 * @return array
+	 */
+	public function andX($values) {
+		return [
+				'$and' => $values
+		];
+	}
+
+	/**
+	 * @param $fields
+	 * @param $comparison
+	 *
+	 * @return array
+	 */
+	private function comparison($fields, $comparison) {
+		if (!is_array($fields)) {
+			$fields = [$fields];
+		}
+		$query = [];
+		foreach ($fields as $field) {
+			$query[$field] = $comparison;
+		}
+		return $query;
+	}
+
+	/**
+	 * @param string $fields
+	 * @param string $value
+	 *
+	 * @return array
+	 */
+	public function like($fields, $value) {
+		return $this->comparison($fields, [
+				'$regex' => $value,
+				'$options' => 'i',
+		]);
+	}
+
+	/**
+	 * Matches all values that are equal to the value specified in the query.
+	 *
+	 * @param string|array $fields
+	 * @param mixed $value
+	 *
+	 * @return array
+	 */
+	public function eq($fields, $value) {
+		return $this->comparison($fields, $value);
+	}
+
+	/**
+	 * Matches values that are greater than the value specified in the query.
+	 *
+	 * @param string|array $fields
+	 * @param mixed $value
+	 *
+	 * @return array
+	 */
+	public function gt($fields, $value) {
+		return $this->comparison($fields, [
+				'$gt' => $value
+		]);
+	}
+
+	/**
+	 * Matches values that are greater than or equal to the value specified in the query.
+	 *
+	 * @param string|array $fields
+	 * @param mixed $value
+	 *
+	 * @return array
+	 */
+	public function gte($fields, $value) {
+		return $this->comparison($fields, [
+				'$gte' => $value
+		]);
+	}
+
+	/**
+	 * Matches any of the values that exist in an array specified in the query.
+	 *
+	 * @param string|array $fields
+	 * @param array $values
+	 *
+	 * @return array
+	 */
+	public function in($fields, $values) {
+		return $this->comparison($fields, [
+				'$in' => $values
+		]);
+	}
+
+	/**
+	 * Matches values that are less than the value specified in the query.
+	 *
+	 * @param string|array $fields
+	 * @param mixed $value
+	 *
+	 * @return array
+	 */
+	public function lt($fields, $value) {
+		return $this->comparison($fields, [
+				'$lt' => $value
+		]);
+	}
+
+	/**
+	 * Matches values that are less than or equal to the value specified in the query.
+	 *
+	 * @param string|array $fields
+	 * @param mixed $value
+	 *
+	 * @return array
+	 */
+	public function lte($fields, $value) {
+		return $this->comparison($fields, [
+				'$lte' => $value
+		]);
+	}
+
+	/**
+	 * Matches all values that are not equal to the value specified in the query.
+	 *
+	 * @param string|array $fields
+	 * @param mixed $value
+	 *
+	 * @return array
+	 */
+	public function ne($fields, $value) {
+		return $this->comparison($fields, [
+				'$ne' => $value
+		]);
+	}
+
+	/**
+	 * Matches values that do not exist in an array specified to the query.
+	 *
+	 * @param string|array $fields
+	 * @param array $values
+	 *
+	 * @return array
+	 */
+	public function nin($fields, $values) {
+		return $this->comparison($fields, [
+				'$nin' => $values
+		]);
+	}
+
+}

--- a/src/Communibase/Query/QueryBuilder.php
+++ b/src/Communibase/Query/QueryBuilder.php
@@ -1,0 +1,68 @@
+<?php
+namespace Communibase\Query;
+
+/**
+ * @package Communibase
+ * @author Kingsquare (source@kingsquare.nl)
+ * @copyright Copyright (c) Kingsquare BV (http://www.kingsquare.nl)
+ */
+class QueryBuilder {
+
+	/**
+	 * @var ExpressionBuilder
+	 */
+	private $expressionBuilder;
+
+	/**
+	 * @var array
+	 */
+	private $query = [];
+
+	/**
+	 * @param array $expr
+	 *
+	 * @return self
+	 */
+	public function add($expr) {
+		$this->query = array_merge($this->query, $expr);
+		return $this;
+	}
+
+	/**
+	 * @param array $expr
+	 *
+	 * @return self
+	 */
+	public function addOr($expr) {
+		$this->query['$or'][] = $expr;
+		return $this;
+	}
+
+	/**
+	 * @param array $expr
+	 *
+	 * @return self
+	 */
+	public function addAnd($expr) {
+		$this->query['$and'][] = $expr;
+		return $this;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getQuery() {
+		return $this->query;
+	}
+
+	/**
+	 * @return ExpressionBuilder
+	 */
+	public function expr() {
+		if (empty($this->expressionBuilder)) {
+			$this->expressionBuilder = new ExpressionBuilder();
+		}
+		return $this->expressionBuilder;
+	}
+
+}


### PR DESCRIPTION
Initial build for a doctrine-like querybuilder for use with communibase....This would allow far more complicated queries to be built without loosing too much readability

i.e.
```
$qb = new \Communibase\QueryBuilder();
$qb = $qb->add($qb->expr()->eq('groupId', 'adf'))
		->add($qb->expr()->lt('startDate', date('c')))
		->add($qb->expr()->orX([
				$qb->expr()->gt('endDate',  date('c')),
				$qb->expr()->eq('endDate', null)
]));
```
instead of
```
$memberships = $this->connection->search('Membership', [
			'groupId' => ['$eq' => 'adf'],
			'startDate' => ['$lt' => date('c')],
			'$or' => [
					['endDate' => ['$gt' => date('c')]],
					['endDate' => null]
			],
		]);
```

The first being able to inject extra stuff more easily ?

Its derived from the Doctrine ODM Querybuilder... 