### PR TITLE
feature: ordering by Ids given

### DIFF
--- a/src/Communibase/Connector.php
+++ b/src/Communibase/Connector.php
@@ -162,7 +162,20 @@ class Connector implements ConnectorInterface
             return [];
         }
 
-        return $this->search($entityType, ['_id' => ['$in' => $validIds]], $params);
+        $doSortByIds = empty($params['sort']);
+        $results = $this->search($entityType, ['_id' => ['$in' => $validIds]], $params);
+        if (!$doSortByIds) {
+            return $results;
+        }
+
+        $flipped = array_flip($validIds);
+        foreach ($results as $result) {
+            $flipped[$result['_id']] = $result;
+        }
+        return array_filter(array_values($flipped), function ($result) {
+            return is_array($result) && !empty($result);
+        });
+
     }
 
     /**


### PR DESCRIPTION
When getting objects by Ids and not passing a specific sort: this feature adds (basic) sorting by the given Ids. IMHO it makes sense to return the full objects in order of the given Id's if not specifically passing a sort to the method.

The sorting of the results by the give ids might be refactored for performance later. It feels kind of clunky right now...