### PR TITLE
async as default; methodCall matching {methodCall}Async is Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ API
 
 "params" is a key value store for e.g. fields, limit, page and/or sort . See [API docs](https://api.communibase.nl/docs/) for more details. In addition to the nodeJS version of this parameter, the fields value may also be an array of fields. This will work more intuitively in PHP environments.
 
+
+#### Sync
+
 ```
 
 $cbc->search($entityType, $selector, $params): entity[];
@@ -69,6 +72,38 @@ $cbc->generateId(): string - Generate a new, fresh Communibase ID
 
 //Use for Files only to get a string with the binary contents
 $cbc->getBinary(id): string;
+
+```
+
+#### Async Usage
+
+Appending `Async` to the method returns a [Promise](https://github.com/guzzle/promise) result.
+
+
+```
+
+$cbc->searchAsync($entityType, $selector, $params): entity[];
+
+$cbc->getAllAsync($entityType, $params): entity[];
+
+$cbc->getByIdAsync($entityType, $id, $params): entity;
+
+$cbc->getByIdsAsync($entityType, $ids, $params): entity[];
+
+$cbc->getIdAsync($entityType, $selector): string;
+
+$cbc->getIdsAsync($entityType, $selector, $params): null|string[];
+
+$cbc->getTemplateAsync($entityType): array;
+
+$cbc->getHistoryAsync($entityType, $id): array;
+
+$cbc->updateAsync($entityType, $properties): responseData;
+
+$cbc->destroyAsync($entityType, $id): responseData;
+
+//Use for Files only to get a string with the binary contents
+$cbc->getBinaryAsync(id): string;
 
 ```
 
@@ -151,6 +186,10 @@ If you're using this app and have questions and/or feedback, please file an issu
 Also we welcome new features and code, so please don't hesitate to get that pull request online!
 
 ## Changelog
+
+* 3.0.0
+
+    * promisified via {method}Async, {method} is delegated to {method}Async and waited
 
 * 2.2.1 bugfix
 

--- a/src/Communibase/ConnectorInterface.php
+++ b/src/Communibase/ConnectorInterface.php
@@ -25,7 +25,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function getTemplate($entityType);
+    public function getTemplateAsync($entityType);
 
     /**
      * Get a single Entity by its id
@@ -38,7 +38,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function getById($entityType, $id, array $params = []);
+    public function getByIdAsync($entityType, $id, array $params = []);
 
     /**
      * Get a single Entity by a ref-string
@@ -61,7 +61,7 @@ interface ConnectorInterface
      *
      * @return array entities
      */
-    public function getByIds($entityType, array $ids, array $params = []);
+    public function getByIdsAsync($entityType, array $ids, array $params = []);
 
     /**
      * Get all entities of a certain type
@@ -71,7 +71,7 @@ interface ConnectorInterface
      *
      * @return array|null
      */
-    public function getAll($entityType, array $params = []);
+    public function getAllAsync($entityType, array $params = []);
 
     /**
      * Get result entityIds of a certain search
@@ -82,7 +82,7 @@ interface ConnectorInterface
      *
      * @return array
      */
-    public function getIds($entityType, array $selector = [], array $params = []);
+    public function getIdsAsync($entityType, array $selector = [], array $params = []);
 
     /**
      * Get the id of an entity based on a search
@@ -92,7 +92,7 @@ interface ConnectorInterface
      *
      * @return array resultData
      */
-    public function getId($entityType, array $selector = []);
+    public function getIdAsync($entityType, array $selector = []);
 
     /**
      * Returns an array of the history for the entity with the following format:
@@ -115,7 +115,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function getHistory($entityType, $id);
+    public function getHistoryAsync($entityType, $id);
 
     /**
      * Search for the given entity by optional passed selector/params
@@ -128,7 +128,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function search($entityType, array $querySelector, array $params = []);
+    public function searchAsync($entityType, array $querySelector, array $params = []);
 
     /**
      * This will save an entity in Communibase. When a _id-field is found, this entity will be updated
@@ -142,7 +142,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function update($entityType, array $properties);
+    public function updateAsync($entityType, array $properties);
 
     /**
      * Finalize an invoice by adding an invoiceNumber to it.
@@ -158,7 +158,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function finalize($entityType, $id);
+    public function finalizeAsync($entityType, $id);
 
     /**
      * Delete something from Communibase
@@ -168,7 +168,7 @@ interface ConnectorInterface
      *
      * @return array resultData
      */
-    public function destroy($entityType, $id);
+    public function destroyAsync($entityType, $id);
 
     /**
      * Get the binary contents of a file by its ID
@@ -181,7 +181,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function getBinary($id);
+    public function getBinaryAsync($id);
 
     /**
      * Uploads the contents of the resource (this could be a file handle) to Communibase
@@ -194,7 +194,7 @@ interface ConnectorInterface
      * @return array|mixed
      * @throws Exception
      */
-    public function updateBinary(StreamInterface $resource, $name, $destinationPath, $id = '');
+    public function updateBinaryAsync(StreamInterface $resource, $name, $destinationPath, $id = '');
 
     /**
      * Add extra headers to be added to each request

--- a/src/Communibase/Logging/DebugStack.php
+++ b/src/Communibase/Logging/DebugStack.php
@@ -44,15 +44,16 @@ class DebugStack implements QueryLogger
                     'executionMS' => 0
             ];
         }
+        return $this->currentQuery;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function stopQuery()
+    public function stopQuery($idx = null)
     {
         if ($this->enabled) {
-            $this->queries[$this->currentQuery]['executionMS'] = microtime(true) - $this->start;
+            $this->queries[$idx !== null ? $idx : $this->currentQuery]['executionMS'] = microtime(true) - $this->start;
         }
     }
 }

--- a/src/Communibase/Logging/QueryLogger.php
+++ b/src/Communibase/Logging/QueryLogger.php
@@ -13,14 +13,16 @@ interface QueryLogger
      * @param array|null $params The Query parameters.
      * @param array|null $data The Query data/payload.
      *
-     * @return void
+     * @return int The query index
      */
     public function startQuery($query, array $params = null, array $data = null);
 
     /**
      * Marks the last started query as stopped. This can be used for timing of queries.
      *
+     * @param integer $idx The query index
+     *
      * @return void
      */
-    public function stopQuery();
+    public function stopQuery($idx = null);
 }

--- a/test/Communibase/Connector/SyncTest.php
+++ b/test/Communibase/Connector/SyncTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace Communibase;
+
+use GuzzleHttp\Promise\FulfilledPromise;
+
+/**
+ * @package Communibase
+ * @author Kingsquare (source@kingsquare.nl)
+ * @copyright Copyright (c) Kingsquare BV (http://www.kingsquare.nl)
+ */
+class SyncTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @test
+     */
+    public function testSync()
+    {
+        $result = $this->getMockConnector()->getById('Person', $this->getMockConnector()->generateId());
+        $this->assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function testAsync()
+    {
+        $this->getMockConnector()->getByIdAsync('Person', $this->getMockConnector()->generateId())->then(function ($result) {
+            $this->assertSame([], $result);
+        })->wait(); // wait to complete the test ;-)
+    }
+
+    /**
+     * @return \Communibase\Connector
+     */
+    protected function getMockConnector() {
+        $mock = $this->getMockBuilder('Communibase\Connector')
+                ->setMethods(['getResult'])
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $mock->expects($this->any())
+            ->method('getResult')
+            ->will($this->returnValue(new FulfilledPromise([])));
+
+        return $mock;
+    }
+}


### PR DESCRIPTION
Connector is promisified (async) ;-) using [Guzzle/Promise](https://github.com/guzzle/promises)

**Implementation**
Methods are all called via `{method}Async` and a call to a method `{method}` will be matched against `{method}Async`, if it matches then call will be [_waited_](https://github.com/guzzle/promises#synchronous-wait) i.e. a sync result.

This supports async usage. and also bc sync usage.

Preferably I would like the interface to stay the same. And be the same as the connector-js. So `search` should be async. Though doing this will break all current usage. Due to this I haven chosen to have all async methods suffixed `{method}Async` and call magic to `{method}` that matches `{method}Async` for bc sync usage.

i.e. method `searchAsync` is sync via `search`
 * this is counter intuitive against the [connector-js](https://github.com/kingsquare/communibase-connector-js) where `search` is async

Caveats;
 * Interface definition has changed