### PR TITLE
async interface conform other connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ API
 "params" is a key value store for e.g. fields, limit, page and/or sort . See [API docs](https://api.communibase.nl/docs/) for more details. In addition to the nodeJS version of this parameter, the fields value may also be an array of fields. This will work more intuitively in PHP environments.
 
 
-#### Sync
+#### Async usage
+
+Returns a [Promise](https://github.com/guzzle/promise) 
+
 
 ```
 
@@ -75,35 +78,35 @@ $cbc->getBinary(id): string;
 
 ```
 
-#### Async Usage
+#### Sync Usage
 
-Appending `Async` to the method returns a [Promise](https://github.com/guzzle/promise) result.
+Appending `Sync` to the method returns the result.
 
 
 ```
 
-$cbc->searchAsync($entityType, $selector, $params): entity[];
+$cbc->searchSync($entityType, $selector, $params): entity[];
 
-$cbc->getAllAsync($entityType, $params): entity[];
+$cbc->getAllSync($entityType, $params): entity[];
 
-$cbc->getByIdAsync($entityType, $id, $params): entity;
+$cbc->getByIdSync($entityType, $id, $params): entity;
 
-$cbc->getByIdsAsync($entityType, $ids, $params): entity[];
+$cbc->getByIdsSync($entityType, $ids, $params): entity[];
 
-$cbc->getIdAsync($entityType, $selector): string;
+$cbc->getIdSync($entityType, $selector): string;
 
-$cbc->getIdsAsync($entityType, $selector, $params): null|string[];
+$cbc->getIdsSync($entityType, $selector, $params): null|string[];
 
-$cbc->getTemplateAsync($entityType): array;
+$cbc->getTemplateSync($entityType): array;
 
-$cbc->getHistoryAsync($entityType, $id): array;
+$cbc->getHistorySync($entityType, $id): array;
 
-$cbc->updateAsync($entityType, $properties): responseData;
+$cbc->updateSync($entityType, $properties): responseData;
 
-$cbc->destroyAsync($entityType, $id): responseData;
+$cbc->destroySync($entityType, $id): responseData;
 
 //Use for Files only to get a string with the binary contents
-$cbc->getBinaryAsync(id): string;
+$cbc->getBinarySync(id): string;
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ API
 
 "params" is a key value store for e.g. fields, limit, page and/or sort . See [API docs](https://api.communibase.nl/docs/) for more details. In addition to the nodeJS version of this parameter, the fields value may also be an array of fields. This will work more intuitively in PHP environments.
 
+
+#### Sync
+
 ```
 
 $cbc->search($entityType, $selector, $params): entity[];
@@ -69,6 +72,38 @@ $cbc->generateId(): string - Generate a new, fresh Communibase ID
 
 //Use for Files only to get a string with the binary contents
 $cbc->getBinary(id): string;
+
+```
+
+#### Async Usage
+
+Appending `Async` to the method returns a [Promise](https://github.com/guzzle/promise) result.
+
+
+```
+
+$cbc->searchAsync($entityType, $selector, $params): entity[];
+
+$cbc->getAllAsync($entityType, $params): entity[];
+
+$cbc->getByIdAsync($entityType, $id, $params): entity;
+
+$cbc->getByIdsAsync($entityType, $ids, $params): entity[];
+
+$cbc->getIdAsync($entityType, $selector): string;
+
+$cbc->getIdsAsync($entityType, $selector, $params): null|string[];
+
+$cbc->getTemplateAsync($entityType): array;
+
+$cbc->getHistoryAsync($entityType, $id): array;
+
+$cbc->updateAsync($entityType, $properties): responseData;
+
+$cbc->destroyAsync($entityType, $id): responseData;
+
+//Use for Files only to get a string with the binary contents
+$cbc->getBinaryAsync(id): string;
 
 ```
 
@@ -151,6 +186,10 @@ If you're using this app and have questions and/or feedback, please file an issu
 Also we welcome new features and code, so please don't hesitate to get that pull request online!
 
 ## Changelog
+
+* 3.0.0
+
+    * promisified via {method}Async, {method} is delegated to {method}Async and waited
 
 * 2.2.1 bugfix
 

--- a/src/Communibase/Connector.php
+++ b/src/Communibase/Connector.php
@@ -13,15 +13,15 @@ use Psr\Http\Message\StreamInterface;
  *
  * For more information see https://communibase.nl
  *
- * Following are IDE hints for non-async method versions:
+ * Following are IDE hints for sync method versions:
  *
- * @method string getTemplate(string $entityType) Returns all the fields according to the definition.
- * @method array getById(string $entityType, string $id) Get an entity by id
- * @method array getByIds(string $entityType, array $ids, array $params = []) Get an array of entities by their ids
- * @method array getAll(string $entityType, array $params) Get all entities of a certain type
- * @method array getId(string $entityType, array $selector) Get the id of an entity based on a search
- * @method array getHistory(string $entityType, string $id) Returns an array of the history for the entity
- * @method array destroy(string $entityType, string $id) Delete something from Communibase
+ * @method string getTemplateSync(string $entityType) Returns all the fields according to the definition.
+ * @method array getByIdSync(string $entityType, string $id) Get an entity by id
+ * @method array getByIdsSync(string $entityType, array $ids, array $params = []) Get an array of entities by their ids
+ * @method array getAllSync(string $entityType, array $params) Get all entities of a certain type
+ * @method array getIdSync(string $entityType, array $selector) Get the id of an entity based on a search
+ * @method array getHistorySync(string $entityType, string $id) Returns an array of the history for the entity
+ * @method array destroySync(string $entityType, string $id) Delete something from Communibase
  *
  * @package Communibase
  * @author Kingsquare (source@kingsquare.nl)
@@ -94,14 +94,14 @@ class Connector implements ConnectorInterface
      *
      * @throws Exception
      */
-    public function getTemplateAsync($entityType)
+    public function getTemplate($entityType)
     {
         $params = [
             'fields' => 'attributes.title',
             'limit' => 1,
         ];
 
-        return $this->searchAsync('EntityType', ['title' => $entityType], $params)->then(function ($definition) {
+        return $this->search('EntityType', ['title' => $entityType], $params)->then(function ($definition) {
             return array_fill_keys(array_merge(['_id'], array_column($definition[0]['attributes'], 'title')), null);
         });
     }
@@ -117,7 +117,7 @@ class Connector implements ConnectorInterface
      *
      * @throws Exception
      */
-    public function getByIdAsync($entityType, $id, array $params = [])
+    public function getById($entityType, $id, array $params = [])
     {
         if (empty($id)) {
             throw new Exception('Id is empty');
@@ -169,7 +169,7 @@ class Connector implements ConnectorInterface
      *
      * @return Promise of result
      */
-    public function getByIdsAsync($entityType, array $ids, array $params = [])
+    public function getByIds($entityType, array $ids, array $params = [])
     {
         $validIds = array_values(array_unique(array_filter($ids, [$this, 'isIdValid'])));
 
@@ -179,7 +179,7 @@ class Connector implements ConnectorInterface
 
         $doSortByIds = empty($params['sort']);
 
-        return $this->searchAsync($entityType, ['_id' => ['$in' => $validIds]], $params)->then(function ($results) use ($doSortByIds, $validIds) {
+        return $this->search($entityType, ['_id' => ['$in' => $validIds]], $params)->then(function ($results) use ($doSortByIds, $validIds) {
             if (!$doSortByIds) {
                 return $results;
             }
@@ -202,7 +202,7 @@ class Connector implements ConnectorInterface
      *
      * @return Promise of result
      */
-    public function getAllAsync($entityType, array $params = [])
+    public function getAll($entityType, array $params = [])
     {
         return $this->doGet($entityType . '.json/crud/', $params);
     }
@@ -216,7 +216,7 @@ class Connector implements ConnectorInterface
      *
      * @return Promise of result
      */
-    public function getIdsAsync($entityType, array $selector = [], array $params = [])
+    public function getIds($entityType, array $selector = [], array $params = [])
     {
         $params['fields'] = '_id';
 
@@ -233,7 +233,7 @@ class Connector implements ConnectorInterface
      *
      * @return Promise of result
      */
-    public function getIdAsync($entityType, array $selector = [])
+    public function getId($entityType, array $selector = [])
     {
         $params = ['limit' => 1];
         $ids = (array)$this->getIds($entityType, $selector, $params);
@@ -262,7 +262,7 @@ class Connector implements ConnectorInterface
      *
      * @throws Exception
      */
-    public function getHistoryAsync($entityType, $id)
+    public function getHistory($entityType, $id)
     {
         return $this->doGet($entityType . '.json/history/' . $id);
     }
@@ -278,7 +278,7 @@ class Connector implements ConnectorInterface
      *
      * @throws Exception
      */
-    public function searchAsync($entityType, array $querySelector, array $params = [])
+    public function search($entityType, array $querySelector, array $params = [])
     {
         return $this->doPost($entityType . '.json/search', $params, $querySelector);
     }
@@ -295,7 +295,7 @@ class Connector implements ConnectorInterface
      *
      * @throws Exception
      */
-    public function updateAsync($entityType, array $properties)
+    public function update($entityType, array $properties)
     {
         $isNew = empty($properties['_id']);
 
@@ -320,7 +320,7 @@ class Connector implements ConnectorInterface
      *
      * @throws Exception
      */
-    public function finalizeAsync($entityType, $id)
+    public function finalize($entityType, $id)
     {
         if ($entityType !== 'Invoice') {
             throw new Exception('Cannot call finalize on ' . $entityType);
@@ -337,7 +337,7 @@ class Connector implements ConnectorInterface
      *
      * @return Promise of result
      */
-    public function destroyAsync($entityType, $id)
+    public function destroy($entityType, $id)
     {
         return $this->doDelete($entityType . '.json/crud/' . $id);
     }
@@ -353,7 +353,7 @@ class Connector implements ConnectorInterface
      *
      * @throws Exception
      */
-    public function getBinaryAsync($id)
+    public function getBinary($id)
     {
         if (!$this->isIdValid($id)) {
             throw new Exception('Invalid $id passed. Please provide one.');
@@ -375,7 +375,7 @@ class Connector implements ConnectorInterface
      * @return array|mixed
      * @throws Exception
      */
-    public function updateBinaryAsync(StreamInterface $resource, $name, $destinationPath, $id = '')
+    public function updateBinary(StreamInterface $resource, $name, $destinationPath, $id = '')
     {
         $metaData = ['path' => $destinationPath];
         if (empty($id)) {
@@ -418,13 +418,15 @@ class Connector implements ConnectorInterface
      */
     public function __call($name, $arguments)
     {
-        $async = $name . 'Async';
-        if (is_callable([$this, $async])) {
-            $promise = call_user_func_array([$this, $async], $arguments);
+        if (preg_match('#(.*)Sync$#', $name, $matches)) {
+            if (is_callable([$this, $matches[1]])) {
+                $promise = call_user_func_array([$this, $matches[1]], $arguments);
 
-            /* @var Promise $promise */
-            return $promise->wait();
+                /* @var Promise $promise */
+                return $promise->wait();
+            }
         }
+        return null;
     }
 
     /**

--- a/src/Communibase/ConnectorInterface.php
+++ b/src/Communibase/ConnectorInterface.php
@@ -2,6 +2,7 @@
 namespace Communibase;
 
 use Communibase\Logging\QueryLogger;
+use GuzzleHttp\Promise\Promise;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -21,11 +22,11 @@ interface ConnectorInterface
      *
      * @param string $entityType
      *
-     * @return array
+     * @return Promise of result
      *
      * @throws Exception
      */
-    public function getTemplateAsync($entityType);
+    public function getTemplate($entityType);
 
     /**
      * Get a single Entity by its id
@@ -34,11 +35,11 @@ interface ConnectorInterface
      * @param string $id
      * @param array $params (optional)
      *
-     * @return array entity
+     * @return Promise of result
      *
      * @throws Exception
      */
-    public function getByIdAsync($entityType, $id, array $params = []);
+    public function getById($entityType, $id, array $params = []);
 
     /**
      * Get a single Entity by a ref-string
@@ -46,7 +47,7 @@ interface ConnectorInterface
      * @param string $ref
      * @param array $parentEntity (optional)
      *
-     * @return array the referred Entity data
+     * @return Promise of result
      *
      * @throws Exception
      */
@@ -59,9 +60,9 @@ interface ConnectorInterface
      * @param array $ids
      * @param array $params (optional)
      *
-     * @return array entities
+     * @return Promise of result
      */
-    public function getByIdsAsync($entityType, array $ids, array $params = []);
+    public function getByIds($entityType, array $ids, array $params = []);
 
     /**
      * Get all entities of a certain type
@@ -69,9 +70,9 @@ interface ConnectorInterface
      * @param string $entityType
      * @param array $params (optional)
      *
-     * @return array|null
+     * @return Promise of result
      */
-    public function getAllAsync($entityType, array $params = []);
+    public function getAll($entityType, array $params = []);
 
     /**
      * Get result entityIds of a certain search
@@ -80,9 +81,9 @@ interface ConnectorInterface
      * @param array $selector (optional)
      * @param array $params (optional)
      *
-     * @return array
+     * @return Promise of result
      */
-    public function getIdsAsync($entityType, array $selector = [], array $params = []);
+    public function getIds($entityType, array $selector = [], array $params = []);
 
     /**
      * Get the id of an entity based on a search
@@ -90,9 +91,9 @@ interface ConnectorInterface
      * @param string $entityType i.e. Person
      * @param array $selector (optional) i.e. ['firstName' => 'Henk']
      *
-     * @return array resultData
+     * @return Promise of result
      */
-    public function getIdAsync($entityType, array $selector = []);
+    public function getId($entityType, array $selector = []);
 
     /**
      * Returns an array of the history for the entity with the following format:
@@ -111,11 +112,11 @@ interface ConnectorInterface
      * @param string $entityType
      * @param string $id
      *
-     * @return array
+     * @return Promise of result
      *
      * @throws Exception
      */
-    public function getHistoryAsync($entityType, $id);
+    public function getHistory($entityType, $id);
 
     /**
      * Search for the given entity by optional passed selector/params
@@ -124,11 +125,11 @@ interface ConnectorInterface
      * @param array $querySelector
      * @param array $params (optional)
      *
-     * @return array
+     * @return Promise of result
      *
      * @throws Exception
      */
-    public function searchAsync($entityType, array $querySelector, array $params = []);
+    public function search($entityType, array $querySelector, array $params = []);
 
     /**
      * This will save an entity in Communibase. When a _id-field is found, this entity will be updated
@@ -138,11 +139,11 @@ interface ConnectorInterface
      * @param string $entityType
      * @param array $properties - the to-be-saved entity data
      *
-     * @returns array resultData
+     * @return Promise of result
      *
      * @throws Exception
      */
-    public function updateAsync($entityType, array $properties);
+    public function update($entityType, array $properties);
 
     /**
      * Finalize an invoice by adding an invoiceNumber to it.
@@ -154,11 +155,11 @@ interface ConnectorInterface
      * @param string $entityType
      * @param string $id
      *
-     * @return array
+     * @return Promise of result
      *
      * @throws Exception
      */
-    public function finalizeAsync($entityType, $id);
+    public function finalize($entityType, $id);
 
     /**
      * Delete something from Communibase
@@ -166,9 +167,9 @@ interface ConnectorInterface
      * @param string $entityType
      * @param string $id
      *
-     * @return array resultData
+     * @return Promise of result
      */
-    public function destroyAsync($entityType, $id);
+    public function destroy($entityType, $id);
 
     /**
      * Get the binary contents of a file by its ID
@@ -181,7 +182,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function getBinaryAsync($id);
+    public function getBinary($id);
 
     /**
      * Uploads the contents of the resource (this could be a file handle) to Communibase
@@ -191,10 +192,11 @@ interface ConnectorInterface
      * @param string $destinationPath
      * @param string $id
      *
-     * @return array|mixed
+     * @return Promise of result
+     *
      * @throws Exception
      */
-    public function updateBinaryAsync(StreamInterface $resource, $name, $destinationPath, $id = '');
+    public function updateBinary(StreamInterface $resource, $name, $destinationPath, $id = '');
 
     /**
      * Add extra headers to be added to each request

--- a/src/Communibase/ConnectorInterface.php
+++ b/src/Communibase/ConnectorInterface.php
@@ -25,7 +25,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function getTemplate($entityType);
+    public function getTemplateAsync($entityType);
 
     /**
      * Get a single Entity by its id
@@ -38,7 +38,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function getById($entityType, $id, array $params = []);
+    public function getByIdAsync($entityType, $id, array $params = []);
 
     /**
      * Get a single Entity by a ref-string
@@ -61,7 +61,7 @@ interface ConnectorInterface
      *
      * @return array entities
      */
-    public function getByIds($entityType, array $ids, array $params = []);
+    public function getByIdsAsync($entityType, array $ids, array $params = []);
 
     /**
      * Get all entities of a certain type
@@ -71,7 +71,7 @@ interface ConnectorInterface
      *
      * @return array|null
      */
-    public function getAll($entityType, array $params = []);
+    public function getAllAsync($entityType, array $params = []);
 
     /**
      * Get result entityIds of a certain search
@@ -82,7 +82,7 @@ interface ConnectorInterface
      *
      * @return array
      */
-    public function getIds($entityType, array $selector = [], array $params = []);
+    public function getIdsAsync($entityType, array $selector = [], array $params = []);
 
     /**
      * Get the id of an entity based on a search
@@ -92,7 +92,7 @@ interface ConnectorInterface
      *
      * @return array resultData
      */
-    public function getId($entityType, array $selector = []);
+    public function getIdAsync($entityType, array $selector = []);
 
     /**
      * Returns an array of the history for the entity with the following format:
@@ -115,7 +115,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function getHistory($entityType, $id);
+    public function getHistoryAsync($entityType, $id);
 
     /**
      * Search for the given entity by optional passed selector/params
@@ -128,7 +128,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function search($entityType, array $querySelector, array $params = []);
+    public function searchAsync($entityType, array $querySelector, array $params = []);
 
     /**
      * This will save an entity in Communibase. When a _id-field is found, this entity will be updated
@@ -142,7 +142,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function update($entityType, array $properties);
+    public function updateAsync($entityType, array $properties);
 
     /**
      * Finalize an invoice by adding an invoiceNumber to it.
@@ -158,7 +158,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function finalize($entityType, $id);
+    public function finalizeAsync($entityType, $id);
 
     /**
      * Delete something from Communibase
@@ -168,7 +168,7 @@ interface ConnectorInterface
      *
      * @return array resultData
      */
-    public function destroy($entityType, $id);
+    public function destroyAsync($entityType, $id);
 
     /**
      * Get the binary contents of a file by its ID
@@ -181,7 +181,7 @@ interface ConnectorInterface
      *
      * @throws Exception
      */
-    public function getBinary($id);
+    public function getBinaryAsync($id);
 
     /**
      * Uploads the contents of the resource (this could be a file handle) to Communibase
@@ -194,7 +194,7 @@ interface ConnectorInterface
      * @return array|mixed
      * @throws Exception
      */
-    public function updateBinary(StreamInterface $resource, $name, $destinationPath, $id = '');
+    public function updateBinaryAsync(StreamInterface $resource, $name, $destinationPath, $id = '');
 
     /**
      * Add extra headers to be added to each request

--- a/src/Communibase/Logging/DebugStack.php
+++ b/src/Communibase/Logging/DebugStack.php
@@ -44,15 +44,16 @@ class DebugStack implements QueryLogger
                     'executionMS' => 0
             ];
         }
+        return $this->currentQuery;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function stopQuery()
+    public function stopQuery($idx = null)
     {
         if ($this->enabled) {
-            $this->queries[$this->currentQuery]['executionMS'] = microtime(true) - $this->start;
+            $this->queries[$idx !== null ? $idx : $this->currentQuery]['executionMS'] = microtime(true) - $this->start;
         }
     }
 }

--- a/src/Communibase/Logging/QueryLogger.php
+++ b/src/Communibase/Logging/QueryLogger.php
@@ -13,14 +13,16 @@ interface QueryLogger
      * @param array|null $params The Query parameters.
      * @param array|null $data The Query data/payload.
      *
-     * @return void
+     * @return int The query index
      */
     public function startQuery($query, array $params = null, array $data = null);
 
     /**
      * Marks the last started query as stopped. This can be used for timing of queries.
      *
+     * @param integer $idx The query index
+     *
      * @return void
      */
-    public function stopQuery();
+    public function stopQuery($idx = null);
 }

--- a/test/Communibase/Connector/SyncTest.php
+++ b/test/Communibase/Connector/SyncTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace Communibase;
+
+use GuzzleHttp\Promise\FulfilledPromise;
+
+/**
+ * @package Communibase
+ * @author Kingsquare (source@kingsquare.nl)
+ * @copyright Copyright (c) Kingsquare BV (http://www.kingsquare.nl)
+ */
+class SyncTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @test
+     */
+    public function testSync()
+    {
+        $result = $this->getMockConnector()->getById('Person', $this->getMockConnector()->generateId());
+        $this->assertSame([], $result);
+    }
+
+    /**
+     * @test
+     */
+    public function testAsync()
+    {
+        $this->getMockConnector()->getByIdAsync('Person', $this->getMockConnector()->generateId())->then(function ($result) {
+            $this->assertSame([], $result);
+        })->wait(); // wait to complete the test ;-)
+    }
+
+    /**
+     * @return \Communibase\Connector
+     */
+    protected function getMockConnector() {
+        $mock = $this->getMockBuilder('Communibase\Connector')
+                ->setMethods(['getResult'])
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $mock->expects($this->any())
+            ->method('getResult')
+            ->will($this->returnValue(new FulfilledPromise([])));
+
+        return $mock;
+    }
+}

--- a/test/Communibase/Connector/SyncTest.php
+++ b/test/Communibase/Connector/SyncTest.php
@@ -14,18 +14,18 @@ class SyncTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function testSync()
+    public function sync()
     {
-        $result = $this->getMockConnector()->getById('Person', $this->getMockConnector()->generateId());
+        $result = $this->getMockConnector()->getByIdSync('Person', $this->getMockConnector()->generateId());
         $this->assertSame([], $result);
     }
 
     /**
      * @test
      */
-    public function testAsync()
+    public function async()
     {
-        $this->getMockConnector()->getByIdAsync('Person', $this->getMockConnector()->generateId())->then(function ($result) {
+        $this->getMockConnector()->getById('Person', $this->getMockConnector()->generateId())->then(function ($result) {
             $this->assertSame([], $result);
         })->wait(); // wait to complete the test ;-)
     }
@@ -33,15 +33,16 @@ class SyncTest extends \PHPUnit_Framework_TestCase
     /**
      * @return \Communibase\Connector
      */
-    protected function getMockConnector() {
+    protected function getMockConnector()
+    {
         $mock = $this->getMockBuilder('Communibase\Connector')
-                ->setMethods(['getResult'])
-                ->disableOriginalConstructor()
-                ->getMock();
+                     ->setMethods(['getResult'])
+                     ->disableOriginalConstructor()
+                     ->getMock();
 
         $mock->expects($this->any())
-            ->method('getResult')
-            ->will($this->returnValue(new FulfilledPromise([])));
+             ->method('getResult')
+             ->will($this->returnValue(new FulfilledPromise([])));
 
         return $mock;
     }


### PR DESCRIPTION
async-first interface. Keeps sync interface-class. Largest userbase incompatible; Though more connector coherent/compatible (connector-js). 

see also #22 

This delivers

 `{method}` (async) and `{method}Sync` (sync)

i.e. `search` (async) and `searchSync` (sync).

This is not BC.

