### PR TITLE
only fetch the fields for the getByRef required extra entities...

### DIFF
--- a/src/Communibase/Connector.php
+++ b/src/Communibase/Connector.php
@@ -144,7 +144,7 @@ class Connector implements ConnectorInterface
         $document = $parentEntity;
         if (strpos($ref['rootDocumentEntityType'], 'parent') === false) {
             if (empty($document['_id']) || $document['_id'] !== $ref['rootDocumentId']) {
-                $document = $this->getById($ref['rootDocumentEntityType'], $ref['rootDocumentId']);
+                $document = $this->getById($ref['rootDocumentEntityType'], $ref['rootDocumentId'], ['fields' => array_column($ref['path'], 'field')]);
             }
 
             if (count($document) === 0) {


### PR DESCRIPTION
This adds the fields param to the GetById()-call made in getByRef. This ensures that only the required paths of the entity which are needed for resolution are fetched. As this works top->down, setting fields to the upper-most level, all subdocuments are still fetched. (just that other top level properties aren't sent over the wire)